### PR TITLE
FEAT: awaitable async call

### DIFF
--- a/go_sdk/async/async.go
+++ b/go_sdk/async/async.go
@@ -1,0 +1,55 @@
+// Package async 提供了 RTM 可等待的异步调用方式。
+//
+// 该包主要用于处理 RTM 异步回调，避免业务逻辑跨越至基础设施 EventHandler 中。
+//
+// 回调上下文存储至公共的 reqIdMap 中，并由 reqIdMapLocker 进行线程安全保护。
+//
+// 使用方法：
+//  1. [NewAsyncCallRtmEventHandler] 创建一个新的 RTM 事件处理器。你可能需要调用 utils 包中的 NewCompositeRtmEventHandler 来组合多个 EventHandler。
+//  2. 使用 [Call] 包装 RTM 的异步方法，他会保存 requestId 并返回一个 [AwaitableAsyncCall]。
+//  3. [AwaitableAsyncCall].Await() 等待异步调用完成。
+package async
+
+import (
+	"context"
+	"sync"
+)
+
+var reqIdMapLocker sync.Mutex
+var reqIdMap map[uint64]AsyncCall = make(map[uint64]AsyncCall) //TODO 如果 asyncCall.Complete 没有被调用，这里可能会产生内存泄露。例如retCode是非0的情况
+
+type RtmAsyncFunc func() (ret int, reqId uint64)
+
+// Call 异步调用 RTM ，返回一个可等待的 [AwaitableAsyncCall]
+// 需要搭配 `NewCompositeRtmEventHandler` 使用
+func Call[T any](callFunc RtmAsyncFunc) AwaitableAsyncCall[T] {
+	reqIdMapLocker.Lock()
+	defer reqIdMapLocker.Unlock()
+
+	var zeroT T
+	asyncCtx := &asyncCallImpl[T]{
+		done:         make(chan struct{}),
+		resultLocker: sync.Mutex{},
+		retCode:      0,
+		reqId:        0,
+
+		result: zeroT,
+		err:    nil,
+	}
+	asyncCtx.retCode, asyncCtx.reqId = callFunc()
+	reqIdMap[asyncCtx.reqId] = asyncCtx
+
+	return asyncCtx
+}
+
+// AsyncCall RTM 异步调用
+type AsyncCall interface {
+	ReturnCode() int
+	RequestId() uint64
+}
+
+// AwaitableAsyncCall 可等待的 RTM 异步调用
+type AwaitableAsyncCall[T any] interface {
+	AsyncCall
+	Await(ctx context.Context) (T, error)
+}

--- a/go_sdk/async/async.go
+++ b/go_sdk/async/async.go
@@ -12,11 +12,18 @@ package async
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"time"
 )
 
 var reqIdMapLocker sync.Mutex
-var reqIdMap map[uint64]AsyncCall = make(map[uint64]AsyncCall) //TODO 如果 asyncCall.Complete 没有被调用，这里可能会产生内存泄露。例如retCode是非0的情况
+var reqIdMap map[uint64]AsyncCall = make(map[uint64]AsyncCall)
+
+// 如果来自 sdk 的 callback 没有发生或者 EventHandler 中没有正确处理，
+// reqIdMap 将会产生内存泄露，或者 Await 方法死锁。
+// 这个超时时间保证 Async 对象一定会进入完成状态。
+const callbackTimeout time.Duration = time.Minute
 
 type RtmAsyncFunc func() (ret int, reqId uint64)
 
@@ -26,17 +33,18 @@ func Call[T any](callFunc RtmAsyncFunc) AwaitableAsyncCall[T] {
 	reqIdMapLocker.Lock()
 	defer reqIdMapLocker.Unlock()
 
-	var zeroT T
-	asyncCtx := &asyncCallImpl[T]{
-		done:         make(chan struct{}),
-		resultLocker: sync.Mutex{},
-		retCode:      0,
-		reqId:        0,
+	retCode, retId := callFunc()
+	asyncCtx := newAsyncCallImpl[T](retCode, retId)
 
-		result: zeroT,
-		err:    nil,
-	}
-	asyncCtx.retCode, asyncCtx.reqId = callFunc()
+	go func() {
+		<-asyncCtx.done // NOTE: 监控 async 完成状态比通过 callback 更可靠
+
+		reqIdMapLocker.Lock()
+		defer reqIdMapLocker.Unlock()
+
+		delete(reqIdMap, asyncCtx.reqId)
+	}()
+
 	reqIdMap[asyncCtx.reqId] = asyncCtx
 
 	return asyncCtx
@@ -48,8 +56,12 @@ type AsyncCall interface {
 	RequestId() uint64
 }
 
+var ErrCallbackTimeout = errors.New("callback timeout")
+
 // AwaitableAsyncCall 可等待的 RTM 异步调用
 type AwaitableAsyncCall[T any] interface {
 	AsyncCall
+	// Await 等待异步调用完成，返回结果和错误信息
+	// 当 callback 未发生或 EventHandler 中没有正确处理时，会返回 ErrCallbackTimeout 错误
 	Await(ctx context.Context) (T, error)
 }

--- a/go_sdk/async/async_call_impl.go
+++ b/go_sdk/async/async_call_impl.go
@@ -1,0 +1,55 @@
+package async
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	agrtm "github.com/AgoraIO-Extensions/Agora-RTM-Server-SDK-Go/go_sdk/rtm"
+)
+
+var _ AwaitableAsyncCall[any] = (*asyncCallImpl[any])(nil)
+
+// asyncCallImpl implements [AsyncCall]
+type asyncCallImpl[T any] struct {
+	done         chan struct{} // 通知通道
+	resultLocker sync.Mutex    // 保护 result & err
+	retCode      int
+	reqId        uint64
+
+	result T
+	err    error
+}
+
+// ReturnCode implements [AsyncCall]
+func (a *asyncCallImpl[T]) ReturnCode() int {
+	return a.retCode
+}
+
+// RequestId implements [AsyncCall]
+func (a *asyncCallImpl[T]) RequestId() uint64 {
+	return a.reqId
+}
+
+// Await implements [AwaitableAsyncCall].
+func (a *asyncCallImpl[T]) Await(ctx context.Context) (T, error) {
+	select {
+	case <-a.done:
+		return a.result, a.err
+	case <-ctx.Done(): // await timeout
+		var zero T
+		return zero, context.Cause(ctx)
+	}
+}
+
+// complete 完成异步调用
+func (a *asyncCallImpl[T]) complete(result T) {
+	a.result = result
+	close(a.done) // 唤醒等待方
+}
+
+// error 完成异步调用
+func (a *asyncCallImpl[T]) error(errorCode int) {
+	a.err = errors.New(agrtm.GetErrorReason(int(errorCode)))
+	close(a.done) // 唤醒等待方
+}

--- a/go_sdk/async/async_call_impl.go
+++ b/go_sdk/async/async_call_impl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	agrtm "github.com/AgoraIO-Extensions/Agora-RTM-Server-SDK-Go/go_sdk/rtm"
 )
@@ -12,13 +13,38 @@ var _ AwaitableAsyncCall[any] = (*asyncCallImpl[any])(nil)
 
 // asyncCallImpl implements [AsyncCall]
 type asyncCallImpl[T any] struct {
-	done         chan struct{} // 通知通道
-	resultLocker sync.Mutex    // 保护 result & err
-	retCode      int
-	reqId        uint64
+	done    chan struct{} // 完成信号
+	retCode int
+	reqId   uint64
+	once    sync.Once // 保证只有一次结果
 
 	result T
 	err    error
+}
+
+func newAsyncCallImpl[T any](retCode int, reqId uint64) *asyncCallImpl[T] {
+	var zeroT T
+	asyncCtx := &asyncCallImpl[T]{
+		done:    make(chan struct{}),
+		retCode: retCode,
+		reqId:   reqId,
+
+		result: zeroT,
+		err:    nil,
+	}
+
+	if retCode != 0 {
+		// retCode非0，不需要等待 callback
+		asyncCtx.errorWithCode(retCode)
+		return asyncCtx
+	}
+
+	go func() {
+		<-time.After(callbackTimeout) // callback timeout
+		asyncCtx.error(ErrCallbackTimeout)
+	}()
+
+	return asyncCtx
 }
 
 // ReturnCode implements [AsyncCall]
@@ -36,20 +62,30 @@ func (a *asyncCallImpl[T]) Await(ctx context.Context) (T, error) {
 	select {
 	case <-a.done:
 		return a.result, a.err
-	case <-ctx.Done(): // await timeout
-		var zero T
-		return zero, context.Cause(ctx)
+	case <-ctx.Done(): // context cancel
+		var zeroT T
+		return zeroT, context.Cause(ctx)
 	}
 }
 
 // complete 完成异步调用
 func (a *asyncCallImpl[T]) complete(result T) {
-	a.result = result
-	close(a.done) // 唤醒等待方
+	a.once.Do(func() {
+		a.result = result
+		close(a.done) // 通知等待方完成
+	})
 }
 
 // error 完成异步调用
-func (a *asyncCallImpl[T]) error(errorCode int) {
-	a.err = errors.New(agrtm.GetErrorReason(int(errorCode)))
-	close(a.done) // 唤醒等待方
+func (a *asyncCallImpl[T]) error(err error) {
+	a.once.Do(func() {
+		a.err = err
+		close(a.done) // 通知等待方完成
+	})
+}
+
+// errorWithCode 完成异步调用
+func (a *asyncCallImpl[T]) errorWithCode(errorCode int) {
+	err := errors.New(agrtm.GetErrorReason(int(errorCode)))
+	a.error(err)
 }

--- a/go_sdk/async/async_test.go
+++ b/go_sdk/async/async_test.go
@@ -1,0 +1,70 @@
+package async_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/AgoraIO-Extensions/Agora-RTM-Server-SDK-Go/go_sdk/async"
+	agrtm "github.com/AgoraIO-Extensions/Agora-RTM-Server-SDK-Go/go_sdk/rtm"
+)
+
+var (
+	appId  string = os.Getenv("APP_ID")
+	userId string = os.Getenv("USER_ID")
+	token  string = os.Getenv("TOKEN")
+)
+
+var (
+	rtmConfig *agrtm.RtmConfig
+	rtmClient *agrtm.IRtmClient
+)
+
+func TestMain(m *testing.M) {
+	rtmConfig = agrtm.NewRtmConfig()
+	rtmConfig.AppId = appId
+	rtmConfig.UserId = userId
+	rtmConfig.EventHandler = async.NewAsyncCallRtmEventHandler() //TODO 需要一个组合事件处理器
+
+	rtmClient = agrtm.NewRtmClient(rtmConfig)
+	defer rtmClient.Release()
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func TestLogin(t *testing.T) {
+	ctx := context.Background()
+
+	// login
+	loginCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	_, err := async.Call[int](func() (ret int, reqId uint64) {
+		ret, reqId = rtmClient.Login(token)
+		log.Printf("Login ret: %d, reqId: %d, token: %s\n", ret, reqId, token)
+		return ret, reqId
+	}).Await(loginCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Println("login success")
+
+	// logout
+	logoutCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	defer cancel()
+
+	_, err = async.Call[int](func() (ret int, reqId uint64) {
+		ret, reqId = rtmClient.Logout()
+		log.Printf("Logout ret: %d, reqId: %d\n", ret, reqId)
+		return ret, reqId
+	}).Await(logoutCtx)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Println("logout success")
+}

--- a/go_sdk/async/handler.go
+++ b/go_sdk/async/handler.go
@@ -1,0 +1,749 @@
+package async
+
+import agrtm "github.com/AgoraIO-Extensions/Agora-RTM-Server-SDK-Go/go_sdk/rtm"
+
+func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
+	return &agrtm.RtmEventHandler{
+		//#region IRtmClient callback
+
+		OnLoginResult: func(requestId uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnLogoutResult: func(requestId uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnRenewTokenResult: func(requestId uint64, serverType agrtm.RtmServiceType, channelName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetOnlineUsersResult: func(requestId uint64, userStateList *agrtm.UserState, count uint, nextPage string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		OnGetUserChannelsResult: func(requestId uint64, channels *agrtm.ChannelInfo, count uint, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//#endregion IRtmClient callback
+
+		//#region MessageChannel callback
+
+		OnJoinResult: func(requestId uint64, channelName string, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnLeaveResult: func(requestId uint64, channelName string, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnSubscribeResult: func(requestId uint64, channelName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//TODO SDK缺少 OnUnsubscribeResult
+
+		OnPublishResult: func(requestId uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetHistoryMessagesResult: func(requestId uint64, messageList []agrtm.HistoryMessage, newStart uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//#endregion MessageChannel callback
+
+		//#region StreamChannel callback
+
+		OnJoinTopicResult: func(requestId uint64, channelName string, userId string, topic string, meta string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnLeaveTopicResult: func(requestId uint64, channelName string, userId string, topic string, meta string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnSubscribeTopicResult: func(requestId uint64, channelName string, userId string, topic string, succeedUsers agrtm.UserList, failedUsers agrtm.UserList, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnPublishTopicMessageResult: func(requestId uint64, channelName string, topic string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnUnsubscribeTopicResult: func(requestId uint64, channelName string, topic string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetSubscribedUserListResult: func(requestId uint64, channelName string, topic string, user *agrtm.UserList, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		// NOTE: OnRenewTokenResult 已归类至 `IRtmClient callback` 中
+
+		//#endregion StreamChannel callback
+
+		//#region Presence callback
+
+		OnWhoNowResult: func(requestId uint64, userStateList *agrtm.UserState, count uint, nextPage string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnWhereNowResult: func(requestId uint64, channels *agrtm.ChannelInfo, count uint, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnPresenceSetStateResult: func(requestId uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnPresenceGetStateResult: func(requestId uint64, state *agrtm.UserState, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnPresenceRemoveStateResult: func(requestId uint64, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//#endregion Presence callback
+
+		//#region Storage callback
+
+		OnSetChannelMetadataResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetChannelMetadataResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, data *agrtm.IMetadata, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnRemoveChannelMetadataResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnUpdateChannelMetadataResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		OnSetUserMetadataResult: func(requestId uint64, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetUserMetadataResult: func(requestId uint64, userId string, data *agrtm.IMetadata, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnRemoveUserMetadataResult: func(requestId uint64, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnUpdateUserMetadataResult: func(requestId uint64, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		OnSubscribeUserMetadataResult: func(requestId uint64, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnUnsubscribeUserMetadataResult: func(requestId uint64, userId string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//#endregion Storage callback
+
+		//#region Lock callback
+
+		OnSetLockResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnAcquireLockResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockName string, errorCode int, errorDetails string) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnReleaseLockResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnRevokeLockResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnGetLocksResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockDetailList *agrtm.LockDetail, count uint, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+		OnRemoveLockResult: func(requestId uint64, channelName string, channelType agrtm.RtmChannelType, lockName string, errorCode int) {
+			//#region reqIdMapLocker.Lock()
+			reqIdMapLocker.Lock()
+
+			iAsyncCall, ok := reqIdMap[requestId]
+			delete(reqIdMap, requestId)
+
+			reqIdMapLocker.Unlock()
+			//#endregion reqIdMapLocker.Lock()
+
+			if ok {
+				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
+				if errorCode != 0 {
+					asyncCall.error(errorCode)
+					return
+				}
+				asyncCall.complete(errorCode)
+			}
+		},
+
+		//#endregion Lock callback
+	}
+
+}

--- a/go_sdk/async/handler.go
+++ b/go_sdk/async/handler.go
@@ -11,7 +11,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -19,7 +18,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -30,7 +29,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -38,7 +36,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -49,7 +47,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -57,7 +54,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -68,7 +65,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -76,7 +72,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -88,7 +84,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -96,7 +91,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -112,7 +107,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -120,7 +114,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -131,7 +125,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -139,7 +132,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -150,7 +143,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -158,7 +150,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -172,7 +164,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -180,7 +171,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -191,7 +182,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -199,7 +189,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -215,7 +205,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -223,7 +212,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -234,7 +223,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -242,7 +230,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -253,7 +241,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -261,7 +248,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -272,7 +259,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -280,7 +266,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -291,7 +277,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -299,7 +284,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -310,7 +295,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -318,7 +302,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -336,7 +320,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -344,7 +327,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -355,7 +338,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -363,7 +345,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -374,7 +356,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -382,7 +363,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -393,7 +374,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -401,7 +381,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -412,7 +392,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -420,7 +399,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -436,7 +415,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -444,7 +422,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -455,7 +433,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -463,7 +440,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -474,7 +451,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -482,7 +458,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -493,7 +469,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -501,7 +476,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -513,7 +488,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -521,7 +495,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -532,7 +506,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -540,7 +513,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -551,7 +524,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -559,7 +531,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -570,7 +542,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -578,7 +549,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -590,7 +561,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -598,7 +568,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -609,7 +579,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -617,7 +586,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -633,7 +602,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -641,7 +609,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -652,7 +620,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -660,7 +627,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -671,7 +638,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -679,7 +645,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -690,7 +656,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -698,7 +663,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -709,7 +674,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -717,7 +681,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)
@@ -728,7 +692,6 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			reqIdMapLocker.Lock()
 
 			iAsyncCall, ok := reqIdMap[requestId]
-			delete(reqIdMap, requestId)
 
 			reqIdMapLocker.Unlock()
 			//#endregion reqIdMapLocker.Lock()
@@ -736,7 +699,7 @@ func NewAsyncCallRtmEventHandler() *agrtm.RtmEventHandler {
 			if ok {
 				asyncCall := (iAsyncCall).(*asyncCallImpl[int])
 				if errorCode != 0 {
-					asyncCall.error(errorCode)
+					asyncCall.errorWithCode(errorCode)
 					return
 				}
 				asyncCall.complete(errorCode)


### PR DESCRIPTION
## 动机

#9 

目前只能通过异步 callback 来等待 `Login` 、接收 `WhoNow` 查询结果等操作。

这会带来不便，特别是容易将业务逻辑代码混入基础层的 RtmEventHandler 中。

希望可以提供类似 JavaScript `Promise` 的可等待对象。

## 功能

- 通过匿名函数包装将异步调用转换为可等待的对象 `AwaitableAsyncCall`
- 通过 `Await()` 方法等待调用结果，可取得返回值和错误
- 具备通过 `context.Context` 的超时机制，符合 Go 对资源生命周期控制的最佳实践
- 完成了测试代码

## 实现细节

1. 定义了一个私有的全局变量 `reqIdMap` 来存储异步调用上下文 `AwaitableAsyncCall` 。
2. `async.Call()` 方法包装了实际的异步调用，负责创建上下文并存入  `reqIdMap`。
3. 当发生回调时，从 `reqIdMap` 中取回上下文。
4. 当上下文完成时，从 `reqIdMap` 移除对象。
5. callback 是通过新增的 NewAsyncCallRtmEventHandler 处理的。

## 使用方法

async_test.go

``` go
	// login
	loginCtx, cancel := context.WithTimeout(ctx, time.Second*3)
	defer cancel()

	_, err := async.Call[int](func() (ret int, reqId uint64) {
		ret, reqId = rtmClient.Login(token)
		log.Printf("Login ret: %d, reqId: %d, token: %s\n", ret, reqId, token)
		return ret, reqId
	}).Await(loginCtx)
	if err != nil {
		panic(err)
	}
```

## 变更

新增 `async` 包。

## TODO

- [x] #22 RtmEventHandler 只能注册一个，因此还需要一个 PR 来实现组合式的 Handler
- [ ] 返回对象目前仅仅为 int 类型的 `errorCode` ，因为每个 `XxxxResult` 回调事件都缺少包装的结构体，但他们都存在 `errorCode`。

