### PR TITLE
CHANGE: out parameter `requestId` move to return value

### DIFF
--- a/go_sdk/rtm/IAgoraRtmClient.go
+++ b/go_sdk/rtm/IAgoraRtmClient.go
@@ -50,7 +50,7 @@ func NewRtmConfig() *RtmConfig {
 		Context:           nil,
 		UseStringUserId:   false,
 		Multipath:         false,
-		EventHandler: nil,
+		EventHandler:      nil,
 		LogConfig:         nil,
 		ProxyConfig:       nil,
 		EncryptionConfig:  nil,
@@ -101,11 +101,6 @@ func NewRtmConfig() *RtmConfig {
 //	        // handle login result
 //	    },
 //	}
-
-
-
-
-
 
 // #region MessageEvent
 type MessageEvent struct {
@@ -591,13 +586,13 @@ func (this_ *StorageEvent) fromC(cEvent *C.struct_C_StorageEvent) {
 }
 
 type IRtmClient struct {
-	rtmClient  unsafe.Pointer
-	handler     *RtmEventHandler
-	history    *IRtmHistory
-	presence   *IRtmPresence
-	lock       *IRtmLock
-	storage    *IRtmStorage
-	isLoggedIn bool
+	rtmClient     unsafe.Pointer
+	handler       *RtmEventHandler
+	history       *IRtmHistory
+	presence      *IRtmPresence
+	lock          *IRtmLock
+	storage       *IRtmStorage
+	isLoggedIn    bool
 	cEventHandler *C.struct_C_IRtmEventHandler
 }
 
@@ -678,7 +673,6 @@ func NewRtmClient(config *RtmConfig) *IRtmClient {
 	}
 	defer freeRtmPrivateConfig(unsafe.Pointer(cPrivateConfig))
 
-	
 	var cEventHandler *C.struct_C_IRtmEventHandler = nil
 	if config.EventHandler != nil {
 		// allocate a c event handler, and keep it alive
@@ -690,18 +684,17 @@ func NewRtmClient(config *RtmConfig) *IRtmClient {
 	}
 
 	client := &IRtmClient{
-		rtmClient:  nil,
-		handler:    config.EventHandler,
+		rtmClient:     nil,
+		handler:       config.EventHandler,
 		cEventHandler: cEventHandler,
-		history:    nil,
-		presence:   nil,
-		lock:       nil,
-		storage:    nil,
-		isLoggedIn: false,
+		history:       nil,
+		presence:      nil,
+		lock:          nil,
+		storage:       nil,
+		isLoggedIn:    false,
 	}
 
 	cEventHandler.userData = unsafe.Pointer(client)
-
 
 	var errorCode C.int
 	rtmClient := C.agora_rtm_client_create(cConfig, &errorCode)
@@ -714,8 +707,6 @@ func NewRtmClient(config *RtmConfig) *IRtmClient {
 
 	//note : cEventHandler.userData will be equal to client!!
 	// assign userdata
-	
-
 
 	// get storage
 	cStorage := C.agora_rtm_client_get_storage(client.rtmClient)
@@ -798,13 +789,13 @@ func (this_ *IRtmClient) Login(token string) (int, uint64) {
 	}
 
 	// do really login
-	var requestId uint64
+	var requestId C.uint64_t
 	cToken := C.CString(token)
 	defer C.free(unsafe.Pointer(cToken))
-	ret := int(C.agora_rtm_client_login(this_.rtmClient,
+	ret := C.agora_rtm_client_login(this_.rtmClient,
 		cToken,
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
+	)
 
 	// update login status
 	if ret == 0 {
@@ -812,7 +803,7 @@ func (this_ *IRtmClient) Login(token string) (int, uint64) {
 	} else {
 		this_.isLoggedIn = false
 	}
-	return int(ret), requestId
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -830,16 +821,16 @@ func (this_ *IRtmClient) Logout() (int, uint64) {
 	if !this_.isLoggedIn {
 		return -10005, 0
 	}
-	var requestId uint64
-	ret := int(C.agora_rtm_client_logout(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_logout(this_.rtmClient,
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
+	)
 
 	// update login status
 	if ret == 0 {
 		this_.isLoggedIn = false
 	}
-	return ret, requestId
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -914,12 +905,12 @@ func (this_ *IRtmClient) RenewToken(token string) (int, uint64) {
 	// do really renew token
 	cToken := C.CString(token)
 	defer C.free(unsafe.Pointer(cToken))
-	var requestId uint64
-	ret := int(C.agora_rtm_client_renew_token(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_renew_token(this_.rtmClient,
 		cToken,
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return int(ret), requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -956,15 +947,15 @@ func (this_ *IRtmClient) Publish(channelName string, message []byte, option *Pub
 		defer freePublishOptions(cOption)
 	}
 
-	var requestId uint64
-	ret := int(C.agora_rtm_client_publish(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_publish(this_.rtmClient,
 		cChannelName,
 		(*C.char)(cMessage),
 		C.size_t(length),
 		(*C.struct_C_PublishOptions)(cOption),
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return ret, requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -986,7 +977,6 @@ func (this_ *IRtmClient) SendChannelMessage(channelName string, message []byte) 
 
 	// do really send channel message
 	length := int(len(message))
-	var requestId uint64
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cMessage := C.CBytes(message)
@@ -998,14 +988,15 @@ func (this_ *IRtmClient) SendChannelMessage(channelName string, message []byte) 
 	cOption := opt.toC()
 	defer freePublishOptions(cOption)
 
-	ret := int(C.agora_rtm_client_publish(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_publish(this_.rtmClient,
 		cChannelName,
 		(*C.char)(cMessage),
 		C.size_t(length),
 		(*C.struct_C_PublishOptions)(cOption),
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return ret, requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -1037,16 +1028,15 @@ func (this_ *IRtmClient) SendUserMessage(userId string, message []byte) (int, ui
 
 	cOption := opt.toC()
 	defer freePublishOptions(cOption)
-	var requestId uint64
-
-	ret := int(C.agora_rtm_client_publish(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_publish(this_.rtmClient,
 		cUserId,
 		(*C.char)(cMessage),
 		C.size_t(length),
 		(*C.struct_C_PublishOptions)(cOption),
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return ret, requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -1069,13 +1059,13 @@ func (this_ *IRtmClient) Subscribe(channelName string, option *SubscribeOptions)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cOption := option.toC()
 	defer freeSubscribeOptions(cOption)
-	var requestId uint64
-	ret := int(C.agora_rtm_client_subscribe(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_subscribe(this_.rtmClient,
 		cChannelName,
 		(*C.struct_C_SubscribeOptions)(cOption),
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return ret, requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -1095,12 +1085,12 @@ func (this_ *IRtmClient) Unsubscribe(channelName string) (int, uint64) {
 	// do really unsubscribe
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
-	var requestId uint64
-	ret := int(C.agora_rtm_client_unsubscribe(this_.rtmClient,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_client_unsubscribe(this_.rtmClient,
 		cChannelName,
 		(*C.uint64_t)(unsafe.Pointer(&requestId)),
-	))
-	return int(ret), requestId
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**

--- a/go_sdk/rtm/IAgoraRtmHistory.go
+++ b/go_sdk/rtm/IAgoraRtmHistory.go
@@ -98,7 +98,7 @@ func NewGetHistoryMessagesOptions() *GetHistoryMessagesOptions {
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmHistory) GetMessages(channelName string, channelType RtmChannelType, options *GetHistoryMessagesOptions, requestId *uint64) int {
+func (this_ *IRtmHistory) GetMessages(channelName string, channelType RtmChannelType, options *GetHistoryMessagesOptions) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
@@ -113,14 +113,15 @@ func (this_ *IRtmHistory) GetMessages(channelName string, channelType RtmChannel
 		cOptions.count = 100
 	}
 
+	var requestId C.uint64_t
 	ret := int(C.agora_rtm_history_get_messages(
 		this_.rtmHistory,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	))
-	return ret
+	return ret, uint64(requestId)
 }
 
 // #endregion IRtmHistory

--- a/go_sdk/rtm/IAgoraRtmLock.go
+++ b/go_sdk/rtm/IAgoraRtmLock.go
@@ -34,19 +34,22 @@ type IRtmLock struct {
  * @param [in] ttl The lock ttl.
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) SetLock(channelName string, channelType RtmChannelType, lockName string, ttl uint32, requestId *uint64) {
+func (this_ *IRtmLock) SetLock(channelName string, channelType RtmChannelType, lockName string, ttl uint32) uint64 {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cLockName := C.CString(lockName)
 	defer C.free(unsafe.Pointer(cLockName))
 
+	var requestId C.uint64_t
 	C.agora_rtm_lock_set_lock(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cLockName,
 		C.uint32_t(ttl),
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -56,14 +59,18 @@ func (this_ *IRtmLock) SetLock(channelName string, channelType RtmChannelType, l
  * @param [in] channelType The type of the channel.
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) GetLocks(channelName string, channelType RtmChannelType, requestId *uint64) {
+func (this_ *IRtmLock) GetLocks(channelName string, channelType RtmChannelType) uint64 {
 	cChannelName := C.CString(channelName)
+
+	var requestId C.uint64_t
 	C.agora_rtm_lock_get_locks(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
 	C.free(unsafe.Pointer(cChannelName))
+
+	return uint64(requestId)
 }
 
 /**
@@ -74,17 +81,21 @@ func (this_ *IRtmLock) GetLocks(channelName string, channelType RtmChannelType, 
  * @param [in] lockName The name of the lock.
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) RemoveLock(channelName string, channelType RtmChannelType, lockName string, requestId *uint64) {
+func (this_ *IRtmLock) RemoveLock(channelName string, channelType RtmChannelType, lockName string) uint64 {
 	cChannelName := C.CString(channelName)
 	cLockName := C.CString(lockName)
+
+	var requestId C.uint64_t
 	C.agora_rtm_lock_remove_lock(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cLockName,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
 	C.free(unsafe.Pointer(cChannelName))
 	C.free(unsafe.Pointer(cLockName))
+
+	return uint64(requestId)
 }
 
 /**
@@ -96,18 +107,22 @@ func (this_ *IRtmLock) RemoveLock(channelName string, channelType RtmChannelType
  * @param [in] retry Whether to automatically retry when acquires lock failed
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) AcquireLock(channelName string, channelType RtmChannelType, lockName string, retry bool, requestId *uint64) {
+func (this_ *IRtmLock) AcquireLock(channelName string, channelType RtmChannelType, lockName string, retry bool) uint64 {
 	cChannelName := C.CString(channelName)
 	cLockName := C.CString(lockName)
+
+	var requestId C.uint64_t
 	C.agora_rtm_lock_acquire_lock(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cLockName,
 		C.bool(retry),
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
 	C.free(unsafe.Pointer(cChannelName))
 	C.free(unsafe.Pointer(cLockName))
+
+	return uint64(requestId)
 }
 
 /**
@@ -118,17 +133,21 @@ func (this_ *IRtmLock) AcquireLock(channelName string, channelType RtmChannelTyp
  * @param [in] lockName The name of the lock.
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) ReleaseLock(channelName string, channelType RtmChannelType, lockName string, requestId *uint64) {
+func (this_ *IRtmLock) ReleaseLock(channelName string, channelType RtmChannelType, lockName string) uint64 {
 	cChannelName := C.CString(channelName)
 	cLockName := C.CString(lockName)
+
+	var requestId C.uint64_t
 	C.agora_rtm_lock_release_lock(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cLockName,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
 	C.free(unsafe.Pointer(cChannelName))
 	C.free(unsafe.Pointer(cLockName))
+
+	return uint64(requestId)
 }
 
 /**
@@ -140,20 +159,24 @@ func (this_ *IRtmLock) ReleaseLock(channelName string, channelType RtmChannelTyp
  * @param [in] owner The lock owner.
  * @param [out] requestId The related request id of this operation.
  */
-func (this_ *IRtmLock) RevokeLock(channelName string, channelType RtmChannelType, lockName string, owner string, requestId *uint64) {
+func (this_ *IRtmLock) RevokeLock(channelName string, channelType RtmChannelType, lockName string, owner string) uint64 {
 	cChannelName := C.CString(channelName)
 	cLockName := C.CString(lockName)
 	cOwner := C.CString(owner)
+
+	var requestId C.uint64_t
 	C.agora_rtm_lock_revoke_lock(this_.rtmLock,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cLockName,
 		cOwner,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
 	C.free(unsafe.Pointer(cChannelName))
 	C.free(unsafe.Pointer(cLockName))
 	C.free(unsafe.Pointer(cOwner))
+
+	return uint64(requestId)
 }
 
 // #endregion IRtmLock

--- a/go_sdk/rtm/IAgoraRtmPresence.go
+++ b/go_sdk/rtm/IAgoraRtmPresence.go
@@ -36,7 +36,7 @@ type IRtmPresence struct {
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) WhoNow(channelName string, channelType RtmChannelType, options *PresenceOptions, requestId *uint64) int {
+func (this_ *IRtmPresence) WhoNow(channelName string, channelType RtmChannelType, options *PresenceOptions) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
@@ -53,13 +53,14 @@ func (this_ *IRtmPresence) WhoNow(channelName string, channelType RtmChannelType
 		cOptions.page = nil
 	}
 
-	ret := int(C.agora_rtm_presence_who_now(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_who_now(this_.rtmPresence,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cOptions,
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -71,15 +72,16 @@ func (this_ *IRtmPresence) WhoNow(channelName string, channelType RtmChannelType
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) WhereNow(userId string, requestId *uint64) int {
+func (this_ *IRtmPresence) WhereNow(userId string) (int, uint64) {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
-	ret := int(C.agora_rtm_presence_where_now(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_where_now(this_.rtmPresence,
 		cUserId,
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -94,7 +96,7 @@ func (this_ *IRtmPresence) WhereNow(userId string, requestId *uint64) int {
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) SetState(channelName string, channelType RtmChannelType, items []*StateItem, count uint, requestId *uint64) int {
+func (this_ *IRtmPresence) SetState(channelName string, channelType RtmChannelType, items []*StateItem, count uint) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
@@ -125,14 +127,15 @@ func (this_ *IRtmPresence) SetState(channelName string, channelType RtmChannelTy
 		}
 	}
 
-	ret := int(C.agora_rtm_presence_set_state(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_set_state(this_.rtmPresence,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cItems,
 		C.size_t(actualCount),
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -147,7 +150,7 @@ func (this_ *IRtmPresence) SetState(channelName string, channelType RtmChannelTy
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) RemoveState(channelName string, channelType RtmChannelType, keys []string, count uint, requestId *uint64) int {
+func (this_ *IRtmPresence) RemoveState(channelName string, channelType RtmChannelType, keys []string, count uint) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
@@ -165,14 +168,15 @@ func (this_ *IRtmPresence) RemoveState(channelName string, channelType RtmChanne
 		}
 	}
 
-	ret := int(C.agora_rtm_presence_remove_state(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_remove_state(this_.rtmPresence,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		unsafe.SliceData(cKeysArr),
 		C.size_t(actualCount),
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -186,21 +190,22 @@ func (this_ *IRtmPresence) RemoveState(channelName string, channelType RtmChanne
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) GetState(channelName string, channelType RtmChannelType, userId string, requestId *uint64) int {
+func (this_ *IRtmPresence) GetState(channelName string, channelType RtmChannelType, userId string) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
-	ret := int(C.agora_rtm_presence_get_state(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_get_state(this_.rtmPresence,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cUserId,
-		(*C.uint64_t)(requestId),
-	))
+		(*C.uint64_t)(&requestId),
+	)
 
-	return ret
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -214,7 +219,7 @@ func (this_ *IRtmPresence) GetState(channelName string, channelType RtmChannelTy
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) GetOnlineUsers(channelName string, channelType RtmChannelType, options *GetOnlineUsersOptions, requestId *uint64) int {
+func (this_ *IRtmPresence) GetOnlineUsers(channelName string, channelType RtmChannelType, options *GetOnlineUsersOptions) (int, uint64) {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
@@ -231,13 +236,14 @@ func (this_ *IRtmPresence) GetOnlineUsers(channelName string, channelType RtmCha
 		cOptions.page = nil
 	}
 
-	ret := int(C.agora_rtm_presence_get_online_users(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_get_online_users(this_.rtmPresence,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cOptions,
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 /**
@@ -249,15 +255,16 @@ func (this_ *IRtmPresence) GetOnlineUsers(channelName string, channelType RtmCha
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmPresence) GetUserChannels(userId string, requestId *uint64) int {
+func (this_ *IRtmPresence) GetUserChannels(userId string) (int, uint64) {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
-	ret := int(C.agora_rtm_presence_get_user_channels(this_.rtmPresence,
+	var requestId C.uint64_t
+	ret := C.agora_rtm_presence_get_user_channels(this_.rtmPresence,
 		cUserId,
-		(*C.uint64_t)(requestId),
-	))
-	return ret
+		(*C.uint64_t)(&requestId),
+	)
+	return int(ret), uint64(requestId)
 }
 
 // #endregion IRtmPresence

--- a/go_sdk/rtm/IAgoraRtmStorage.go
+++ b/go_sdk/rtm/IAgoraRtmStorage.go
@@ -248,7 +248,7 @@ func (this_ *IRtmStorage) CreateMetadata() *IMetadata {
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) SetChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string, requestId *uint64) int {
+func (this_ *IRtmStorage) SetChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string) uint64 {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cLockName := C.CString(lockName)
@@ -286,15 +286,17 @@ func (this_ *IRtmStorage) SetChannelMetadata(channelName string, channelType Rtm
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_set_channel_metadata(this_.rtmStorage,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cData,
 		cOptions,
 		cLockName,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+
+	return uint64(requestId)
 }
 
 /**
@@ -311,7 +313,7 @@ func (this_ *IRtmStorage) SetChannelMetadata(channelName string, channelType Rtm
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) UpdateChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string, requestId *uint64) {
+func (this_ *IRtmStorage) UpdateChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string) uint64 {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cLockName := C.CString(lockName)
@@ -349,14 +351,17 @@ func (this_ *IRtmStorage) UpdateChannelMetadata(channelName string, channelType 
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_update_channel_metadata(this_.rtmStorage,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cData,
 		cOptions,
 		cLockName,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -373,7 +378,7 @@ func (this_ *IRtmStorage) UpdateChannelMetadata(channelName string, channelType 
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) RemoveChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string, requestId *uint64) {
+func (this_ *IRtmStorage) RemoveChannelMetadata(channelName string, channelType RtmChannelType, data *IMetadata, options *MetadataOptions, lockName string) uint64 {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 	cLockName := C.CString(lockName)
@@ -411,14 +416,17 @@ func (this_ *IRtmStorage) RemoveChannelMetadata(channelName string, channelType 
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_remove_channel_metadata(this_.rtmStorage,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
 		cData,
 		cOptions,
 		cLockName,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -432,15 +440,18 @@ func (this_ *IRtmStorage) RemoveChannelMetadata(channelName string, channelType 
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) GetChannelMetadata(channelName string, channelType RtmChannelType, requestId *uint64) {
+func (this_ *IRtmStorage) GetChannelMetadata(channelName string, channelType RtmChannelType) uint64 {
 	cChannelName := C.CString(channelName)
 	defer C.free(unsafe.Pointer(cChannelName))
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_get_channel_metadata(this_.rtmStorage,
 		cChannelName,
 		C.enum_C_RTM_CHANNEL_TYPE(channelType),
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -455,7 +466,7 @@ func (this_ *IRtmStorage) GetChannelMetadata(channelName string, channelType Rtm
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) SetUserMetadata(userId string, data *IMetadata, options *MetadataOptions, requestId *uint64) {
+func (this_ *IRtmStorage) SetUserMetadata(userId string, data *IMetadata, options *MetadataOptions) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
@@ -491,12 +502,15 @@ func (this_ *IRtmStorage) SetUserMetadata(userId string, data *IMetadata, option
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_set_user_metadata(this_.rtmStorage,
 		cUserId,
 		cData,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -511,7 +525,7 @@ func (this_ *IRtmStorage) SetUserMetadata(userId string, data *IMetadata, option
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) UpdateUserMetadata(userId string, data *IMetadata, options *MetadataOptions, requestId *uint64) {
+func (this_ *IRtmStorage) UpdateUserMetadata(userId string, data *IMetadata, options *MetadataOptions) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
@@ -547,12 +561,15 @@ func (this_ *IRtmStorage) UpdateUserMetadata(userId string, data *IMetadata, opt
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_update_user_metadata(this_.rtmStorage,
 		cUserId,
 		cData,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -567,7 +584,7 @@ func (this_ *IRtmStorage) UpdateUserMetadata(userId string, data *IMetadata, opt
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) RemoveUserMetadata(userId string, data *IMetadata, options *MetadataOptions, requestId *uint64) {
+func (this_ *IRtmStorage) RemoveUserMetadata(userId string, data *IMetadata, options *MetadataOptions) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
@@ -603,12 +620,15 @@ func (this_ *IRtmStorage) RemoveUserMetadata(userId string, data *IMetadata, opt
 		}
 	}
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_remove_user_metadata(this_.rtmStorage,
 		cUserId,
 		cData,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -621,14 +641,17 @@ func (this_ *IRtmStorage) RemoveUserMetadata(userId string, data *IMetadata, opt
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) GetUserMetadata(userId string, requestId *uint64) {
+func (this_ *IRtmStorage) GetUserMetadata(userId string) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_get_user_metadata(this_.rtmStorage,
 		cUserId,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -640,14 +663,17 @@ func (this_ *IRtmStorage) GetUserMetadata(userId string, requestId *uint64) {
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) SubscribeUserMetadata(userId string, requestId *uint64) {
+func (this_ *IRtmStorage) SubscribeUserMetadata(userId string) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
+	var requestId C.uint64_t
 	C.agora_rtm_storage_subscribe_user_metadata(this_.rtmStorage,
 		cUserId,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 /**
@@ -659,15 +685,17 @@ func (this_ *IRtmStorage) SubscribeUserMetadata(userId string, requestId *uint64
  * - 0: Success.
  * - < 0: Failure.
  */
-func (this_ *IRtmStorage) UnsubscribeUserMetadata(userId string) {
+func (this_ *IRtmStorage) UnsubscribeUserMetadata(userId string) uint64 {
 	cUserId := C.CString(userId)
 	defer C.free(unsafe.Pointer(cUserId))
 
-	var requestId uint64
+	var requestId C.uint64_t
 	C.agora_rtm_storage_unsubscribe_user_metadata(this_.rtmStorage,
 		cUserId,
 		(*C.uint64_t)(&requestId),
 	)
+
+	return uint64(requestId)
 }
 
 // #endregion IRtmStorage

--- a/go_sdk/rtm/IAgoraStreamChannel.go
+++ b/go_sdk/rtm/IAgoraStreamChannel.go
@@ -300,7 +300,7 @@ type IStreamChannel struct {
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) Join(options *JoinChannelOptions, requestId *uint64) int {
+func (this_ *IStreamChannel) Join(options *JoinChannelOptions) uint64 {
 	cOptions := C.C_JoinChannelOptions_New()
 	defer C.C_JoinChannelOptions_Delete(cOptions)
 	cOptions.token = C.CString(options.Token)
@@ -309,11 +309,13 @@ func (this_ *IStreamChannel) Join(options *JoinChannelOptions, requestId *uint64
 	cOptions.withPresence = C.bool(options.WithPresence)
 	cOptions.withLock = C.bool(options.WithLock)
 	cOptions.beQuiet = C.bool(options.BeQuiet)
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_join(this_.streamChannel,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -324,15 +326,15 @@ func (this_ *IStreamChannel) Join(options *JoinChannelOptions, requestId *uint64
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) RenewToken(token string) int {
+func (this_ *IStreamChannel) RenewToken(token string) uint64 {
 	cToken := C.CString(token)
 	defer C.free(unsafe.Pointer(cToken))
-	var requestId uint64
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_renew_token(this_.streamChannel,
 		cToken,
 		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -342,11 +344,12 @@ func (this_ *IStreamChannel) RenewToken(token string) int {
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) Leave(requestId *uint64) int {
+func (this_ *IStreamChannel) Leave() uint64 {
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_leave(this_.streamChannel,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -368,7 +371,7 @@ func (this_ *IStreamChannel) GetChannelName() string {
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) JoinTopic(topic string, options *JoinTopicOptions, requestId *uint64) int {
+func (this_ *IStreamChannel) JoinTopic(topic string, options *JoinTopicOptions) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
 	cOptions := C.C_JoinTopicOptions_New()
@@ -385,12 +388,14 @@ func (this_ *IStreamChannel) JoinTopic(topic string, options *JoinTopicOptions, 
 		cOptions.meta = nil
 		cOptions.syncWithMedia = C.bool(false)
 	}
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_join_topic(this_.streamChannel,
 		cTopic,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -404,12 +409,11 @@ func (this_ *IStreamChannel) JoinTopic(topic string, options *JoinTopicOptions, 
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) PublishTopicMessage(topic string, message string, length uint, option *TopicMessageOptions) int {
+func (this_ *IStreamChannel) PublishTopicMessage(topic string, message string, length uint, option *TopicMessageOptions) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
 	cMessage := C.CString(message)
 	defer C.free(unsafe.Pointer(cMessage))
-	var requestId uint64
 	cOption := C.C_TopicMessageOptions_New()
 	defer C.C_TopicMessageOptions_Delete(cOption)
 	if option != nil {
@@ -422,6 +426,8 @@ func (this_ *IStreamChannel) PublishTopicMessage(topic string, message string, l
 		cOption.sendTs = 0
 		cOption.customType = nil
 	}
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_publish_topic_message(this_.streamChannel,
 		cTopic,
 		cMessage,
@@ -429,7 +435,7 @@ func (this_ *IStreamChannel) PublishTopicMessage(topic string, message string, l
 		cOption,
 		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -440,14 +446,16 @@ func (this_ *IStreamChannel) PublishTopicMessage(topic string, message string, l
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) LeaveTopic(topic string, requestId *uint64) int {
+func (this_ *IStreamChannel) LeaveTopic(topic string) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_leave_topic(this_.streamChannel,
 		cTopic,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -459,7 +467,7 @@ func (this_ *IStreamChannel) LeaveTopic(topic string, requestId *uint64) int {
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) SubscribeTopic(topic string, options *TopicOptions, requestId *uint64) int {
+func (this_ *IStreamChannel) SubscribeTopic(topic string, options *TopicOptions) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
 	cOptions := C.C_TopicOptions_New()
@@ -485,12 +493,14 @@ func (this_ *IStreamChannel) SubscribeTopic(topic string, options *TopicOptions,
 		cOptions.users = nil
 		cOptions.userCount = 0
 	}
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_subscribe_topic(this_.streamChannel,
 		cTopic,
 		cOptions,
-		(*C.uint64_t)(requestId),
+		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -501,7 +511,7 @@ func (this_ *IStreamChannel) SubscribeTopic(topic string, options *TopicOptions,
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) UnsubscribeTopic(topic string, options *TopicOptions) int {
+func (this_ *IStreamChannel) UnsubscribeTopic(topic string, options *TopicOptions) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
 	cOptions := C.C_TopicOptions_New()
@@ -527,13 +537,14 @@ func (this_ *IStreamChannel) UnsubscribeTopic(topic string, options *TopicOption
 		cOptions.users = nil
 		cOptions.userCount = 0
 	}
-	var requestId uint64
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_unsubscribe_topic(this_.streamChannel,
 		cTopic,
 		cOptions,
 		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**
@@ -545,15 +556,16 @@ func (this_ *IStreamChannel) UnsubscribeTopic(topic string, options *TopicOption
 * - 0: Success.
 * - < 0: Failure.
  */
-func (this_ *IStreamChannel) GetSubscribedUserList(topic string) int {
+func (this_ *IStreamChannel) GetSubscribedUserList(topic string) uint64 {
 	cTopic := C.CString(topic)
 	defer C.free(unsafe.Pointer(cTopic))
-	var requestId uint64
+
+	var requestId C.uint64_t
 	C.agora_rtm_stream_channel_get_subscribed_user_list(this_.streamChannel,
 		cTopic,
 		(*C.uint64_t)(&requestId),
 	)
-	return 0
+	return uint64(requestId)
 }
 
 /**


### PR DESCRIPTION
## 动机

`requestId` 是一个传出参数，根据 Go 语言风格，应该将其作为返回值

## 修改

统一 `requestId` 风格，以返回值形式返回，从函数参数中移除。

